### PR TITLE
replaced the block explorer site

### DIFF
--- a/p2pool/bitcoin/networks/litecoin.py
+++ b/p2pool/bitcoin/networks/litecoin.py
@@ -20,9 +20,9 @@ POW_FUNC = lambda data: pack.IntType(256).unpack(__import__('ltc_scrypt').getPoW
 BLOCK_PERIOD = 150 # s
 SYMBOL = 'LTC'
 CONF_FILE_FUNC = lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'Litecoin') if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/Litecoin/') if platform.system() == 'Darwin' else os.path.expanduser('~/.litecoin'), 'litecoin.conf')
-BLOCK_EXPLORER_URL_PREFIX = 'http://explorer.litecoin.net/block/'
-ADDRESS_EXPLORER_URL_PREFIX = 'http://explorer.litecoin.net/address/'
-TX_EXPLORER_URL_PREFIX = 'http://explorer.litecoin.net/tx/'
+BLOCK_EXPLORER_URL_PREFIX = 'https://chainz.cryptoid.info/ltc/block.dws?'
+ADDRESS_EXPLORER_URL_PREFIX = 'https://chainz.cryptoid.info/ltc/address.dws?'
+TX_EXPLORER_URL_PREFIX = 'https://chainz.cryptoid.info/ltc/tx.dws?'
 SANE_TARGET_RANGE = (2**256//1000000000 - 1, 2**256//1000 - 1)
 DUMB_SCRYPT_DIFF = 2**16
 DUST_THRESHOLD = 0.03e8


### PR DESCRIPTION
replaced the block explorer site with "chainz.cryptoid.info/ltc" because its a mess on the "exporer.litecoin.net" when you have large transfers out of your address, and that you have to scroll all the way down to the bottom to check the latest transaction to your address