### PR TITLE
Higher sane target range

### DIFF
--- a/p2pool/bitcoin/networks/bitcoincash.py
+++ b/p2pool/bitcoin/networks/bitcoincash.py
@@ -25,6 +25,6 @@ CONF_FILE_FUNC = lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'Bitco
 BLOCK_EXPLORER_URL_PREFIX = 'https://blockchair.com/bitcoin-cash/block/'
 ADDRESS_EXPLORER_URL_PREFIX = 'https://blockchair.com/bitcoin-cash/address/'
 TX_EXPLORER_URL_PREFIX = 'https://blockchair.com/bitcoin-cash/transaction/'
-SANE_TARGET_RANGE = (2**256//2**32//1000000 - 1, 2**256//2**32 - 1)
+SANE_TARGET_RANGE = (2**256//2**32//10000000 - 1, 2**256//2**32 - 1)
 DUMB_SCRYPT_DIFF = 1
 DUST_THRESHOLD = 0.001e8

--- a/p2pool/bitcoin/networks/bitcoincash.py
+++ b/p2pool/bitcoin/networks/bitcoincash.py
@@ -25,6 +25,6 @@ CONF_FILE_FUNC = lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'Bitco
 BLOCK_EXPLORER_URL_PREFIX = 'https://blockchair.com/bitcoin-cash/block/'
 ADDRESS_EXPLORER_URL_PREFIX = 'https://blockchair.com/bitcoin-cash/address/'
 TX_EXPLORER_URL_PREFIX = 'https://blockchair.com/bitcoin-cash/transaction/'
-SANE_TARGET_RANGE = (2**256//2**32//10000000 - 1, 2**256//2**32 - 1)
+SANE_TARGET_RANGE = (2**256//2**32//100000000 - 1, 2**256//2**32 - 1)
 DUMB_SCRYPT_DIFF = 1
 DUST_THRESHOLD = 0.001e8


### PR DESCRIPTION
Nicehash keeps returning max target < 1000000 errors, so me and dgenr8 did some trial and error and found that adding to SANE_TARGET_RANGE works.