### PR TITLE
Change RPC check for bitcoincash testnet

### DIFF
--- a/p2pool/bitcoin/networks/bitcoincash_testnet.py
+++ b/p2pool/bitcoin/networks/bitcoincash_testnet.py
@@ -13,8 +13,8 @@ P2P_PORT = 18333
 ADDRESS_VERSION = 111
 RPC_PORT = 18332
 RPC_CHECK = defer.inlineCallbacks(lambda bitcoind: defer.returnValue(
-            'bitcoin' in (yield bitcoind.rpc_help()) and
-                         (yield bitcoind.rpc_getblockchaininfo())['chain'] == 'test'
+            'getreceivedbyaddress' in (yield bitcoind.rpc_help()) and
+            (yield bitcoind.rpc_getinfo())['testnet']
         ))
 SUBSIDY_FUNC = lambda height: 50*100000000 >> (height + 1)//210000
 POW_FUNC = data.hash256


### PR DESCRIPTION
ABC 0.18.3 removed some entries from help, so switching checks should make it work again.