### PR TITLE
authorize should return true result to miner

### DIFF
--- a/p2pool/bitcoin/stratum.py
+++ b/p2pool/bitcoin/stratum.py
@@ -32,6 +32,7 @@ class StratumRPCMiningProvider(object):
         self.username = username.strip()
         
         reactor.callLater(0, self._send_work)
+        return True
     
     def _send_work(self):
         try:


### PR DESCRIPTION
When miner authorizes to pool the pool returns a result to the miner.
That result should be true if the miner is authorized.