### PR TITLE
Allow for new AUX POW.

### DIFF
--- a/p2pool/main.py
+++ b/p2pool/main.py
@@ -498,6 +498,9 @@ def run():
     parser.add_argument('--merged',
         help='call getauxblock on this url to get work for merged mining (example: http://ncuser:ncpass@127.0.0.1:10332/)',
         type=str, action='append', default=[], dest='merged_urls')
+    parser.add_argument('--merged_addr',
+        help='call createauxblock/submitauxblock on this url to get work for merged mining and use payout address (example: payout%http://ncuser:ncpass@127.0.0.1:10332/)',
+        type=str, action='append', default=[], dest='merged_urls_addr')
     parser.add_argument('--coinbtext',
         help='append this text to the coinbase',
         type=str, action='append', default=[], dest='coinb_texts')
@@ -655,13 +658,20 @@ def run():
     else:
         args.pubkey_hash = None
     
-    def separate_url(url):
+    def separate_url(url, addr=False):
+        paddr = None
+        if addr:
+            if '%' not in url:
+                parser.error('payoutaddress not specifed in merged url')
+            paddr, url = url.split('%')
+            print("Found payout %s for %s" % (paddr, url))
         s = urlparse.urlsplit(url)
         if '@' not in s.netloc:
             parser.error('merged url netloc must contain an "@"')
         userpass, new_netloc = s.netloc.rsplit('@', 1)
-        return urlparse.urlunsplit(s._replace(netloc=new_netloc)), userpass
+        return urlparse.urlunsplit(s._replace(netloc=new_netloc)), userpass, paddr
     merged_urls = map(separate_url, args.merged_urls)
+    merged_urls += [separate_url(x, addr=True) for x in args.merged_urls_addr]
     
     if args.logfile is None:
         args.logfile = os.path.join(datadir_path, 'log')

--- a/p2pool/work.py
+++ b/p2pool/work.py
@@ -76,19 +76,23 @@ class WorkerBridge(worker_interface.WorkerBridge):
         self.merged_work = variable.Variable({})
         
         @defer.inlineCallbacks
-        def set_merged_work(merged_url, merged_userpass):
+        def set_merged_work(merged_url, merged_userpass, merged_address):
             merged_proxy = jsonrpc.HTTPProxy(merged_url, dict(Authorization='Basic ' + base64.b64encode(merged_userpass)))
             while self.running:
-                auxblock = yield deferral.retry('Error while calling merged getauxblock on %s:' % (merged_url,), 30)(merged_proxy.rpc_getauxblock)()
+                if merged_address:
+                    auxblock = yield deferral.retry('Error while calling merged createauxblock on %s:' % (merged_url,), 30)(merged_proxy.rpc_createauxblock)(merged_address)
+                else:
+                    auxblock = yield deferral.retry('Error while calling merged getauxblock on %s:' % (merged_url,), 30)(merged_proxy.rpc_getauxblock)()
                 target = auxblock['target'] if 'target' in auxblock else auxblock['_target']
                 self.merged_work.set(math.merge_dicts(self.merged_work.value, {auxblock['chainid']: dict(
                     hash=int(auxblock['hash'], 16),
                     target='p2pool' if target == 'p2pool' else pack.IntType(256).unpack(target.decode('hex')),
                     merged_proxy=merged_proxy,
+                    merged_address=merged_address,
                 )}))
                 yield deferral.sleep(1)
-        for merged_url, merged_userpass in merged_urls:
-            set_merged_work(merged_url, merged_userpass)
+        for merged_url, merged_userpass, merged_address in merged_urls:
+            set_merged_work(merged_url, merged_userpass, merged_address)
         
         @self.merged_work.changed.watch
         def _(new_merged_work):
@@ -462,7 +466,11 @@ class WorkerBridge(worker_interface.WorkerBridge):
             for aux_work, index, hashes in mm_later:
                 try:
                     if pow_hash <= aux_work['target'] or p2pool.DEBUG:
-                        df = deferral.retry('Error submitting merged block: (will retry)', 10, 10)(aux_work['merged_proxy'].rpc_getauxblock)(
+                        if aux_work['merged_address']:
+                            sub_meth = aux_work['merged_proxy'].rpc_submitauxblock
+                        else:
+                            sub_meth = aux_work['merged_proxy'].rpc.getauxblock
+                        df = deferral.retry('Error submitting merged block: (will retry)', 10, 10)(sub_meth)(
                             pack.IntType(256, 'big').pack(aux_work['hash']).encode('hex'),
                             bitcoin_data.aux_pow_type.pack(dict(
                                 merkle_tx=dict(


### PR DESCRIPTION
getauxblock is being depreciated and replaced by createauxblock and
submitauxblock. This allows for specifying a payment address when asking
for an auxblock instead of getting a wallet address so you don't have to
run a wallet where p2pool has access. Most coins support both methods,
some only support the old method (Terricoin is an example) and some only
support the new method (Myriadcoin is an example). Use `--merged` for
the old style and `--merged_addr` for the new style.