### PR TITLE
Check that ismine attribute is present

### DIFF
--- a/p2pool/main.py
+++ b/p2pool/main.py
@@ -135,7 +135,7 @@ def main(args, net, datadir_path, merged_urls, worker_endpoint):
             
             if address is not None:
                 res = yield deferral.retry('Error validating cached address:', 5)(lambda: bitcoind.rpc_validateaddress(address))()
-                if not res['isvalid'] or not res['ismine']:
+                if not res['isvalid'] or (hasattr(res, 'ismine') and not res['ismine']):
                     print '    Cached address is either invalid or not controlled by local bitcoind!'
                     address = None
 


### PR DESCRIPTION
validateaddress call may not always return `ismine` attribute, so this just checks that attribute is present before using in comparison. If you have a `data/litecoin/cached_payout_address` file in place, then it's likely you've run into an exception error that this fix addresses.