### PR TITLE
fix(work): Bootstrap new sharechain with PaddingBugfixShare (V35) ins…

### DIFF
--- a/p2pool/work.py
+++ b/p2pool/work.py
@@ -297,7 +297,9 @@ class WorkerBridge(worker_interface.WorkerBridge):
         
         previous_share = self.node.tracker.items[self.node.best_share_var.value] if self.node.best_share_var.value is not None else None
         if previous_share is None:
-            share_type = p2pool_data.Share
+            # Bootstrap with current share type (PaddingBugfixShare V35)
+            # Not ancient Share (V17) which hasn't been used since 2016
+            share_type = p2pool_data.PaddingBugfixShare
         else:
             previous_share_type = type(previous_share)
             


### PR DESCRIPTION
Bootstrap new sharechain with PaddingBugfixShare (V35) instead of ancient Share (V17)

When starting a fresh sharechain (isolated network, PERSIST=False, or after complete network death), the code incorrectly defaults to Share (VERSION 17) instead of PaddingBugfixShare (VERSION 35).

Share V17 was deprecated years ago. New sharechains should start with the current production share type (V35) to enable proper version signaling.

Bug discovered while testing V36 migration on isolated test network - shares were stuck signaling for V35 forever but never actually upgrading because type(previous_share) was always Share.

This bug doesn't affect the global network because nodes always sync existing V35 shares from peers, so previous_share is never None. It only manifests when bootstrapping a completely fresh sharechain.