### PR TITLE
web: fix TypeError when best_share_hash is None

### DIFF
--- a/p2pool/web.py
+++ b/p2pool/web.py
@@ -359,7 +359,7 @@ def get_web_root(wb, datadir_path, bitcoind_getinfo_var, stop_event=variable.Eve
     new_root.putChild('verified_heads', WebInterface(lambda: ['%064x' % x for x in node.tracker.verified.heads]))
     new_root.putChild('tails', WebInterface(lambda: ['%064x' % x for t in node.tracker.tails for x in node.tracker.reverse.get(t, set())]))
     new_root.putChild('verified_tails', WebInterface(lambda: ['%064x' % x for t in node.tracker.verified.tails for x in node.tracker.verified.reverse.get(t, set())]))
-    new_root.putChild('best_share_hash', WebInterface(lambda: '%064x' % node.best_share_var.value))
+    new_root.putChild('best_share_hash', WebInterface(lambda: '%064x' % node.best_share_var.value if node.best_share_var.value is not None else ''))
     new_root.putChild('my_share_hashes', WebInterface(lambda: ['%064x' % my_share_hash for my_share_hash in wb.my_share_hashes]))
     new_root.putChild('my_share_hashes50', WebInterface(lambda: ['%064x' % my_share_hash for my_share_hash in list(wb.my_share_hashes)[:50]]))
     def get_share_data(share_hash_str):


### PR DESCRIPTION
When p2pool starts fresh with no shares, `node.best_share_var.value` is `None`. Accessing the `/best_share_hash` endpoint crashes with:

```
TypeError: %x format: a number is required, not NoneType
```

This happens when opening the web interface before any shares have been generated.

**Fix:** Return an empty string instead of crashing when no shares exist yet.