### PR TITLE
util: fix weakref race condition in Event.watch_weakref

### DIFF
--- a/p2pool/util/variable.py
+++ b/p2pool/util/variable.py
@@ -16,7 +16,7 @@ class Event(object):
         return self.watch(func)
     def watch_weakref(self, obj, func):
         # func must not contain a reference to obj!
-        watch_id = self.watch(lambda *args: func(obj_ref(), *args))
+        watch_id = self.watch(lambda *args: func(obj_ref(), *args) if obj_ref() is not None else None)
         obj_ref = weakref.ref(obj, lambda _: self.unwatch(watch_id))
     def watch(self, func):
         id = self.id_generator.next()


### PR DESCRIPTION
When a `TrackerSkipList` is garbage collected, there is a race between the weakref destructor (which calls `unwatch`) and the `removed` event callback. If the event fires after GC but before `unwatch` deregisters the watcher, `obj_ref()` returns `None` and the callback crashes:

```
AttributeError: 'NoneType' object has no attribute 'forget_item'
```

Full traceback:
```
File "p2pool/node.py", line 345, in clean_tracker
    self.tracker.verified.remove(share_hash)
File "p2pool/util/forest.py", line 361, in remove
    Tracker.remove(self, item_hash)
File "p2pool/util/forest.py", line 330, in remove
    self.removed.happened(item)
File "p2pool/util/variable.py", line 42, in happened
    func(*event)
File "p2pool/util/variable.py", line 19, in <lambda>
    watch_id = self.watch(lambda *args: func(obj_ref(), *args))
File "p2pool/util/forest.py", line 15, in <lambda>
    self.tracker.removed.watch_weakref(self, lambda self, item: self.forget_item(item.hash))
AttributeError: 'NoneType' object has no attribute 'forget_item'
```

**Fix:** Guard the `watch_weakref` callback against a dead weakref by checking `obj_ref() is not None` before invoking the function.